### PR TITLE
Fixed Links and Capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to this repository as a hands-on approach to working with Github.
 
 Contributing to this repository is as simple as following proper Github flow for
 code contribution. If you don't know what that is or how to do it, I recommend
-checking out [this](https://guides.github.com/introduction/flow/) page on github.
+checking out [this](https://guides.github.com/introduction/flow/) page on Github.
 For those who already know a little bit about Git, a TL;DR is listed here as well.
 
 ## Github Flow

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ For those who already know a little bit about Git, a TL;DR is listed here as wel
 
 If you want to practice your Git Flow skills, you can either create an issue
 in the [issue tracker](https://github.com/quigley-c/git-flow-example/issues)
-or clone this repository to make a [pull request](
-https://github.com/quigley-c/git-flow-example-pulls).
+or clone this repository to make a [pull request](https://github.com/quigley-c/git-flow-example-pulls).
 
 If you're going to make a pull request (PR from here on out) you should follow
 the basic steps.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For those who already know a little bit about Git, a TL;DR is listed here as wel
 
 If you want to practice your Git Flow skills, you can either create an issue
 in the [issue tracker](https://github.com/quigley-c/git-flow-example/issues)
-or clone this repository to make a [pull request](https://github.com/quigley-c/git-flow-example-pulls).
+or clone this repository to make a [pull request](https://github.com/quigley-c/git-flow-example/pulls).
 
 If you're going to make a pull request (PR from here on out) you should follow
 the basic steps.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the basic steps.
 
 ## quigley-c
 
-The maintainer of this repository, [quigley-c](https://github.com:quigley-c), is
+The maintainer of this repository, [quigley-c](https://github.com/quigley-c), is
 an Allegheny College Computer Science alum who is passionate about coding and
 teamwork in computer science through Git. He is always available to answer any
 questions about using the Github issue tracker, creating pull requests, or


### PR DESCRIPTION
This PR was created to address Issue #4 Broken Link in README. It fixes the links both to the PR page of the repository and quigley-c's profile page. It also capitalizes the second use of "Github" under the "How To Contribute" section of the README. 